### PR TITLE
fix a url to download fbv from an active repo

### DIFF
--- a/package/fbv/fbv.mk
+++ b/package/fbv/fbv.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 FBV_VERSION = 1.0b
-FBV_SITE = http://s-tech.elsat.net.pl/fbv
+FBV_SITE = http://repository.timesys.com/buildsources/f/fbv/fbv-1.0b
 
 FBV_LICENSE = GPL-2.0
 FBV_LICENSE_FILES = COPYING


### PR DESCRIPTION
The original host of fbv is now offline.  I just picked a randomly googled repo that seemed ok, but I'm not really sure what the best approach is here.