### PR TITLE
ntp: Fix on a133 (TrimUI Brick/Smart Pro).

### DIFF
--- a/package/ntp/ntp.mk
+++ b/package/ntp/ntp.mk
@@ -41,6 +41,9 @@ else
 NTP_CONF_OPTS += --with-hardenfile=default
 endif
 
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_A133),y)
+NTP_CONF_OPTS += --disable-linuxcaps
+else \
 ifeq ($(BR2_PACKAGE_LIBCAP),y)
 NTP_CONF_OPTS += --enable-linuxcaps
 NTP_DEPENDENCIES += libcap


### PR DESCRIPTION
This fixes the long-standing issue on TrimUI Brick/Smart Pro whereby ntpd dies before it can set time from a network time source, resulting in large clock drift or a clock that's never been set properly to begin with.

What's happening here is that, on boot, ntpd creates and binds sockets to port 123 on each network interface.  However since there's no link on the wlan0 interface, ntpd doesn't bind to it, but it does track and dynamically bind to interfaces when they come up later.  However, when the wlan0 interface comes up on the a133 kernel, ntpd logs this error and exits:

```
socket(AF_INET, SOCK_DGRAM, 0) failed on address [redacted]: Permission denied
unexpected socket() error Permission denied code 13 (not EPROTONOSUPPORT nor EAFNOSUPPORT nor EPFNOSUPPORT) - exiting
```

I've confirmed that this error is due to a bug in the a133 kernel whereby it incorrectly requires the CAP_NET_RAW capability to create any AF_INET sockets (not just SOCK_RAW ones as the name implies).  In typical usage, ntpd is called with the `-u` parameter to drop privileges as a non-root user, but uses libcap to maintain the capabilities it needs (set time, bind to privileged ports, etc).  It does not, however, request CAP_NET_RAW since it should have no need for this capability.

Even without `-u`, ntpd still tests for the presence of capabilities support within the kernel (https://github.com/ntp-project/ntp/blob/NTP_4_2_8P18/ntpd/ntpd.c#L1193) and this alone triggers the bug on a133, resulting in all subsequent calls to `socket(AF_INET, ...)` to error.  This includes breaking name resolution as a socket is used to determine the local interface IP for remote hosts (https://github.com/ntp-project/ntp/blob/NTP_4_2_8P18/ntpd/ntp_io.c#L4087).

Due to the bizarreness of the issue, the simplest solution here is to compile ntp without libcap ("linuxcaps") support on a133.